### PR TITLE
Implement ReplayBuffer with tests

### DIFF
--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -1,0 +1,43 @@
+import os
+import sys
+import torch
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from training.buffer import ReplayBuffer
+
+
+def test_wraparound():
+    buf = ReplayBuffer(3, torch.device('cpu'))
+    drops = [
+        buf.append(torch.full((2,), i), token=i, reward=i % 2, conf=0.0)
+        for i in range(4)
+    ]
+    assert len(buf) == 3
+    assert drops[-1] is True
+    assert sorted(buf._token_buf[:len(buf)].tolist()) == [1, 2, 3]
+
+
+def test_accepted_count():
+    buf = ReplayBuffer(4, torch.device('cpu'))
+    for i, r in enumerate([1.0, 0.0, 1.0]):
+        buf.append(torch.zeros(1), i, r, 0.0)
+    assert buf.accepted_count() == 2
+
+
+def test_sample_shapes_dtypes():
+    buf = ReplayBuffer(5, torch.device('cpu'))
+    for i in range(5):
+        buf.append(torch.zeros(4), i, 1.0, 0.5)
+    batch = buf.sample(3)
+    assert batch['hidden'].shape == (3, 4)
+    assert batch['token'].dtype == torch.long
+    assert batch['reward'].dtype == torch.float32
+    assert batch['conf'].dtype == torch.float32
+
+
+def test_insufficient_positives():
+    buf = ReplayBuffer(2, torch.device('cpu'))
+    buf.append(torch.zeros(1), 0, 0.0, 0.2)
+    with pytest.raises(ValueError):
+        buf.sample(1, accepted_only=True)

--- a/training/buffer.py
+++ b/training/buffer.py
@@ -1,0 +1,111 @@
+import logging
+from typing import Dict, Optional
+
+import torch
+
+__all__ = ["ReplayBuffer"]
+
+
+class ReplayBuffer:
+    """Fixed-capacity token replay buffer stored on a single device."""
+
+    def __init__(self, capacity: int, device: torch.device):
+        self.capacity = int(capacity)
+        self.device = device
+
+        # Storage buffers
+        self._hidden_buf: Optional[torch.Tensor] = None
+        self._token_buf = torch.empty(self.capacity, dtype=torch.long, device=device)
+        self._reward_buf = torch.empty(self.capacity, dtype=torch.float32, device=device)
+        self._conf_buf = torch.empty(self.capacity, dtype=torch.float32, device=device)
+
+        # Pointers
+        self._write_idx = 0
+        self._size = 0
+
+    @torch.no_grad()
+    def append(
+        self,
+        hidden: torch.Tensor,
+        token: int,
+        reward: float,
+        conf: float,
+    ) -> bool:
+        """Append a transition and return ``True`` if an old slot was overwritten."""
+        if self._hidden_buf is None:
+            shape = (self.capacity,) + tuple(hidden.shape)
+            self._hidden_buf = torch.empty(shape, dtype=hidden.dtype, device=self.device)
+            logging.debug("ReplayBuffer allocated with shape %s", str(shape))
+
+        idx = self._write_idx
+        drop = self._size == self.capacity
+        if drop:
+            logging.debug("Overwriting index %d with token %d", idx, int(token))
+
+        self._hidden_buf[idx].copy_(hidden.detach().to(self.device))
+        self._token_buf[idx] = int(token)
+        self._reward_buf[idx] = float(reward)
+        self._conf_buf[idx] = float(conf)
+
+        self._write_idx = (idx + 1) % self.capacity
+        if not drop:
+            self._size += 1
+        return drop
+
+    @torch.no_grad()
+    def sample(self, batch_size: int, accepted_only: bool = True) -> Dict[str, torch.Tensor]:
+        """Sample a batch of transitions uniformly."""
+        if self._size == 0 or self._hidden_buf is None:
+            raise ValueError("Buffer is empty")
+
+        mask = self._reward_buf[: self._size] == 1.0
+        if not accepted_only:
+            mask = torch.ones_like(mask, dtype=torch.bool)
+
+        indices = torch.nonzero(mask, as_tuple=False).squeeze(1)
+        count = int(indices.numel())
+        if batch_size > count:
+            raise ValueError("Not enough samples of requested type")
+
+        perm = torch.randperm(count, device=self.device)[:batch_size]
+        choice = indices[perm]
+        logging.debug("Sampling %d entries (accepted_only=%s)", batch_size, accepted_only)
+
+        return {
+            "hidden": self._hidden_buf[choice].clone(),
+            "token": self._token_buf[choice].clone(),
+            "reward": self._reward_buf[choice].clone(),
+            "conf": self._conf_buf[choice].clone(),
+        }
+
+    @torch.no_grad()
+    def accepted_count(self) -> int:
+        if self._size == 0:
+            return 0
+        return int((self._reward_buf[: self._size] == 1.0).sum().item())
+
+    def __len__(self) -> int:
+        return self._size
+
+    @torch.no_grad()
+    def clear(self, accepted_only: bool = False) -> None:
+        if not accepted_only:
+            self._size = 0
+            self._write_idx = 0
+            return
+
+        if self._size == 0:
+            return
+
+        keep_mask = self._reward_buf[: self._size] != 1.0
+        keep_indices = torch.nonzero(keep_mask, as_tuple=False).squeeze(1)
+        keep_count = int(keep_indices.numel())
+
+        if keep_count:
+            self._hidden_buf[:keep_count].copy_(self._hidden_buf[keep_indices])
+            self._token_buf[:keep_count].copy_(self._token_buf[keep_indices])
+            self._reward_buf[:keep_count].copy_(self._reward_buf[keep_indices])
+            self._conf_buf[:keep_count].copy_(self._conf_buf[keep_indices])
+
+        self._size = keep_count
+        self._write_idx = keep_count % self.capacity


### PR DESCRIPTION
## Summary
- add new torchscriptable `ReplayBuffer`
- provide unit tests covering wrap-around, accepted count, sampling and errors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887e7ff7ff083248f564f5a9833830b