### PR TITLE
Improve PG signal, adapter hygiene, CTAR computation, and evaluation path

### DIFF
--- a/evaluation/acceptance.py
+++ b/evaluation/acceptance.py
@@ -13,6 +13,7 @@ from training.kv import (
     clear_all_kv,
 )
 from training.utils import ctar, free_cuda
+from training.modeling import exit_logits_from_hidden_k, cast_exit_to_base_dtype, adapter_guard
 
 __all__ = ["eval_acceptance"]
 
@@ -28,40 +29,40 @@ def _top1(logits: torch.Tensor) -> int:
 def eval_acceptance(spec: EarlyExitLlamaForCausalLM, tok, prompts: List[str],
                    rollout_len: int, steps_per_prompt: int = 1,
                    dump_debug: bool = False, dump_path: Optional[str] = None, topk: int = 5,
-                   quiet: bool = False) -> Tuple[float, Dict[int, float]]:
+                   quiet: bool = False, k_max: int = 4) -> Tuple[float, Dict[int, float]]:
     global _KV_WARN_COUNT
     spec.eval()
+    cast_exit_to_base_dtype(spec)
     dev = next(spec.parameters()).device
-    accepts: List[int] = []
+    accepts_seq: List[List[int]] = []
     dbg_out: List[Dict] = []
     for p in prompts:
         enc = tok(p, return_tensors="pt").to(dev)
         prime_kv_full(spec, enc["input_ids"])
         ids_last = enc["input_ids"][:, -1:]
+        cur_bits: List[int] = []
         for _ in range(steps_per_prompt * rollout_len):
-            v_logits = spec.verifier_logits_for_next(ids_last)
+            with adapter_guard(spec, "verify"):
+                v_logits = spec.verifier_logits_for_next(ids_last)
             if not torch.isfinite(v_logits).all():
-                accepts.append(0)
+                cur_bits.append(0)
                 break
             v_top1 = _top1(v_logits)
             kv_bytes_b, kv_seq_b = estimate_kv_cache(spec)
-            d_hidden = drafter_hidden_no_cache(spec, ids_last)
+            with adapter_guard(spec, "draft"):
+                d_hidden = drafter_hidden_no_cache(spec, ids_last)
             kv_bytes_a, kv_seq_a = estimate_kv_cache(spec)
             if (kv_bytes_b != kv_bytes_a or kv_seq_b != kv_seq_a) and _KV_WARN_COUNT < _KV_WARN_LIMIT:
                 print("[kv] WARNING: probe seems to have mutated past_key_values during eval.", flush=True)
                 _KV_WARN_COUNT += 1
-            h = d_hidden.squeeze(1).float()
-            if hasattr(spec, "exit_pre_norm") and spec.exit_pre_norm is not None:
-                h = spec.exit_pre_norm(h)
-            d_logits = spec.exit_proj(h)
-            if hasattr(spec, "exit_logit_scale"):
-                d_logits = spec.exit_logit_scale * d_logits
+            with adapter_guard(spec, "draft"):
+                d_logits = exit_logits_from_hidden_k(spec, d_hidden)
             if not torch.isfinite(d_logits).all():
-                accepts.append(0)
+                cur_bits.append(0)
                 d_top1 = -1
             else:
                 d_top1 = _top1(d_logits)
-                accepts.append(int(d_top1 == v_top1))
+                cur_bits.append(int(d_top1 == v_top1))
             if dump_debug and dump_path:
                 try:
                     v_prob, v_id = torch.topk(torch.softmax(v_logits.float(), dim=-1)[0], k=topk)
@@ -78,13 +79,15 @@ def eval_acceptance(spec: EarlyExitLlamaForCausalLM, tok, prompts: List[str],
             v_token = torch.tensor([[v_top1]], device=ids_last.device, dtype=ids_last.dtype)
             advance_kv_with_committed(spec, v_token)
             ids_last = v_token
+        accepts_seq.append(cur_bits)
         clear_all_kv(spec)
         if not quiet:
             free_cuda("(eval prompt done)")
         else:
             free_cuda("")
-    acc = sum(accepts) / max(1, len(accepts))
-    c = {w: ctar(accepts, w) for w in (1, 2, 3, 4)}
+    flat = sum((seq for seq in accepts_seq), [])
+    acc = sum(flat) / max(1, len(flat))
+    c = {w: ctar(accepts_seq, w) for w in range(1, k_max + 1)}
     if dump_debug and dump_path and dbg_out:
         with open(dump_path, "a") as f:
             for rec in dbg_out:

--- a/evaluation/inference_kangaroo.py
+++ b/evaluation/inference_kangaroo.py
@@ -1,217 +1,58 @@
-"""Generate answers with local models.
-
-Usage:
-python3 gen_model_answer.py --model-path lmsys/fastchat-t5-3b-v1.0 --model-id fastchat-t5-3b-v1.0
-"""
+"""Generate answers with DVI speculative decoding."""
 import argparse
-import torch
 import os
+import torch
 
 from fastchat.utils import str_to_torch_dtype
 from evaluation.eval import run_eval, reorg_answer_file
-from transformers import AutoModelForCausalLM, AutoTokenizer
+from transformers import AutoTokenizer
 from kangaroo.kangaroo_model import KangarooModel
+from training.spec_decode import generate_with_dvi_spec
 
-def kangaroo_forward(inputs, model, tokenizer, max_new_tokens, do_sample=False, max_length = 2048, EARLY_STOP_LAYER = 2, SPECULATIVE_DECODING_STEPS = 6, threshold = 0.6):
-    context_tokens = inputs.input_ids
-    device = context_tokens.device
-    token_eos = tokenizer.eos_token_id
-    batch_size, context_length = context_tokens.shape
-    global_tokens = torch.ones((batch_size, max_length), dtype=torch.long, device=device) * token_eos
-    global_position_ids = torch.LongTensor([[i for i in range(max_length)]]).to(device)
-    accept_length_list = [1]
 
-    start_index = context_length
-    global_tokens[:, :start_index] = context_tokens
-
-    # Init KV-chache and sample the first token
-    with torch.no_grad():
-        position_ids = global_position_ids[:, :start_index]
-        output = model.base_model(context_tokens, position_ids=position_ids, output_hidden_states=True)
-        model.base_model.past_key_values = list(output.past_key_values)
-        hidden_state = output.hidden_states[-1]
-        logits = output.logits # batchsize, input_length, vocab_size
-        global_tokens[:, start_index] = torch.argmax(logits[:, -1, :], dim=-1).item()
-        hidden_state_early = output.hidden_states[EARLY_STOP_LAYER]
-
-        # KV-cache for the adapter
-        hidden_state, adapter_past_key_values = model.adapter_model.forward_early_stop(inputs_embeds=hidden_state_early[:,:,:], position_ids=global_position_ids[:, :context_length], use_cache=True) 
-
-    total_inference_steps = 0
-
-    with torch.no_grad():
-        max_infer_steps = min(max_length, start_index + max_new_tokens)
-        stop = False
-
-        while start_index < max_infer_steps - 1 - SPECULATIVE_DECODING_STEPS:
-
-            start_index_copy = start_index
-            end_index = start_index + 1
-            
-            # STEP 1: Small model decoding
-            for step in range(1 + SPECULATIVE_DECODING_STEPS):
-                assert adapter_past_key_values[0][0].shape[2] <= end_index-1, "{} - {}".format(adapter_past_key_values[0][0].shape, end_index-1)
-                in_tokens_small = global_tokens[:, end_index-1:end_index]
-                if adapter_past_key_values[0][0].shape[2] < end_index-1: 
-                    # As illustrated in the framework of Kangaroo, once all drafted tokens are accepted, the KV-cache of the last draft token for the adapter is missing.
-                    position_ids = global_position_ids[:, start_index-1:end_index]
-                    hidden_state_early_last = exited_hidden_states[:,-1:,:]
-                else:
-                    position_ids = global_position_ids[:, end_index-1:end_index]
-                    hidden_state_early_last = None
-                
-                hidden_state_early = model.base_model.forward_draft_or_large_model(in_tokens_small=in_tokens_small[:,-1:], position_ids=position_ids[:,-1:])
-                
-                if step==0:
-                    exited_hidden_states = None
-
-                exited_hidden_states = hidden_state_early if exited_hidden_states is None else torch.cat([exited_hidden_states, hidden_state_early], dim = 1)
-                
-                if hidden_state_early_last is not None:
-                    hidden_state_early = torch.cat([hidden_state_early_last, hidden_state_early], dim = 1)
-
-                # early exiting 
-                if step == SPECULATIVE_DECODING_STEPS or (step > 0 and predict_score < threshold):
-                    break
-
-                hidden_state, adapter_past_key_values = model.adapter_model.forward_early_stop(inputs_embeds=hidden_state_early, position_ids=position_ids, past_key_values=adapter_past_key_values, use_cache=True)
-
-                predict_logits = model.head_model(hidden_state[:,-1:,:]).float() 
-                global_tokens[:, end_index] = torch.argmax(predict_logits[:, -1, :], dim=-1)
-                
-                end_index += 1
-                predict_score = predict_logits.softmax(dim=-1).max().item()
-
-            # STEP2: Big model inference
-            position_ids = global_position_ids[:, start_index:end_index]
-            assert model.base_model.past_key_values[EARLY_STOP_LAYER][0].shape[2] == start_index, "{} - {}".format(model.base_model.past_key_values[EARLY_STOP_LAYER][0].shape, start_index)
-            assert exited_hidden_states.shape[1] == position_ids.shape[1]
-            hidden_state_, hidden_state = model.base_model.forward_draft_or_large_model(in_features_large=exited_hidden_states, position_ids=position_ids)
-            
-            logits = model.head_model(hidden_state).float() # batchsize, input_length, vocab_size
-            output_tokens = torch.argmax(logits[:, :, :], dim=-1)
-
-            # Verification for greedy decoding
-            output_lenght = end_index - start_index
-            for i in range(output_lenght):
-                if i == output_lenght-1 or output_tokens[0, i] == token_eos or output_tokens[0, i] != global_tokens[0, start_index+1+i]:
-                    global_tokens[0, start_index+1+i] = output_tokens[0, i]
-                    start_index = start_index+1+i
-                    if output_tokens[0, i] == token_eos:
-                        stop = True
-                    break
-
-            accept_length_list.append(start_index - start_index_copy)
-            hidden_state = hidden_state[:, :output_lenght-(end_index-start_index), :]
-
-            # STEP 4: Post process KV-cache
-            if model.base_model.past_key_values[0][0].shape[2] > start_index:
-                past_key_values_large_ = []
-                for k,v in model.base_model.past_key_values:
-                    past_key_values_large_.append((k[:,:,:start_index,:], v[:,:,:start_index,:]))
-                model.base_model.past_key_values = past_key_values_large_
-
-            if adapter_past_key_values[0][0].shape[2] > start_index:
-                adapter_past_key_values_ = []
-                for k,v in adapter_past_key_values:
-                    adapter_past_key_values_.append((k[:,:,:start_index,:], v[:,:,:start_index,:]))
-                adapter_past_key_values = tuple(adapter_past_key_values_)
-                del adapter_past_key_values_
-            
-            total_inference_steps += 1
-
-            if stop:
-                break
-
-    output_ids = global_tokens[0, :start_index+1].tolist()
-    new_token = start_index - context_length + 1
-    idx = len(accept_length_list) - 1
-    return [output_ids], new_token, idx, accept_length_list
+def kangaroo_forward(inputs, model, tokenizer, max_new_tokens, do_sample=False,
+                     EARLY_STOP_LAYER=2, SPECULATIVE_DECODING_STEPS=6, **kwargs):
+    enc = {"input_ids": inputs.input_ids}
+    outputs, metrics = generate_with_dvi_spec(
+        model,
+        tokenizer,
+        enc=enc,
+        max_new_tokens=max_new_tokens,
+        draft_k=SPECULATIVE_DECODING_STEPS,
+        greedy=not do_sample,
+        early_layer=EARLY_STOP_LAYER,
+        temperature=kwargs.get("temperature", 1.0),
+    )
+    seq = torch.cat([inputs.input_ids[0], outputs[0]], dim=0).tolist()
+    new_token = len(outputs[0])
+    idx = metrics.steps
+    acc_list = [metrics.accepted // max(1, metrics.steps)] * max(1, metrics.steps)
+    return [seq], new_token, idx, acc_list
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "--model-path",
-        type=str,
-        required=True,
-    )
-    parser.add_argument(
-        "--adapter-path",
-        type=str,
-        required=True,
-    )
+    parser.add_argument("--model-path", type=str, required=True)
+    parser.add_argument("--adapter-path", type=str, required=True)
     parser.add_argument("--model-id", type=str, required=True)
-    parser.add_argument(
-        "--bench-name",
-        type=str,
-        default="mt_bench",
-        help="The name of the benchmark question set.",
-    )
-    parser.add_argument(
-        "--question-begin",
-        type=int,
-        help="A debug option. The begin index of questions.",
-    )
-    parser.add_argument(
-        "--question-end",
-        type=int,
-        help="A debug option. The end index of questions."
-    )
-    parser.add_argument("--answer-file", type=str, help="The output answer file.")
-    parser.add_argument(
-        "--max-new-tokens",
-        type=int,
-        default=1024,
-        help="The maximum number of new generated tokens.",
-    )
-    parser.add_argument(
-        "--num-choices",
-        type=int,
-        default=1,
-        help="How many completion choices to generate.",
-    )
-    parser.add_argument(
-        "--num-gpus-per-model",
-        type=int,
-        default=1,
-        help="The number of GPUs per model.",
-    )
-    parser.add_argument(
-        "--num-gpus-total", type=int, default=1, help="The total number of GPUs."
-    )
-    parser.add_argument(
-        "--threshold",
-        type=float,
-        default=0.4,
-        help="The temperature for medusa sampling.",
-    )
-    parser.add_argument(
-        "--exitlayer",
-        type=int,
-        default=2,
-        help="The temperature for medusa sampling.",
-    )
-    parser.add_argument(
-        "--steps",
-        type=int,
-        default=6,
-        help="The number of GPUs per model.",
-    )
-
-    parser.add_argument(
-        "--dtype",
-        type=str,
-        default="float16",
-        choices=["float32", "float64", "float16", "bfloat16"],
-        help="Override the default dtype. If not set, it will use float16 on GPU.",
-    )
-
+    parser.add_argument("--bench-name", type=str, default="mt_bench")
+    parser.add_argument("--question-begin", type=int)
+    parser.add_argument("--question-end", type=int)
+    parser.add_argument("--answer-file", type=str)
+    parser.add_argument("--max-new-tokens", type=int, default=1024)
+    parser.add_argument("--num-choices", type=int, default=1)
+    parser.add_argument("--num-gpus-per-model", type=int, default=1)
+    parser.add_argument("--num-gpus-total", type=int, default=1)
+    parser.add_argument("--threshold", type=float, default=0.4)
+    parser.add_argument("--exitlayer", type=int, default=2)
+    parser.add_argument("--steps", type=int, default=6)
+    parser.add_argument("--dtype", type=str, default="float16",
+                        choices=["float32", "float64", "float16", "bfloat16"],
+                        help="Override the default dtype. If not set, it will use float16 on GPU.")
     args = parser.parse_args()
 
-    question_file = f"data/question.jsonl"
-
-    model = KangarooModel(args.model_path, args.adapter_path, args, EARLY_STOP_LAYER = args.exitlayer)
+    question_file = "data/question.jsonl"
+    model = KangarooModel(args.model_path, args.adapter_path, args, EARLY_STOP_LAYER=args.exitlayer)
     tokenizer = AutoTokenizer.from_pretrained(args.model_path)
     do_sample = False
 
@@ -221,7 +62,6 @@ if __name__ == "__main__":
     for run in range(3):
         answer_file = f"data/{args.bench_name}/{args.model_id}/{run}.jsonl"
         print(f"Output to {answer_file}")
-
         run_eval(
             model=model,
             tokenizer=tokenizer,
@@ -238,7 +78,6 @@ if __name__ == "__main__":
             do_sample=do_sample,
             threshold=args.threshold,
             SPECULATIVE_DECODING_STEPS=args.steps,
-            EARLY_STOP_LAYER=args.exitlayer
+            EARLY_STOP_LAYER=args.exitlayer,
         )
-
         reorg_answer_file(answer_file)

--- a/tests/test_adapter_hygiene.py
+++ b/tests/test_adapter_hygiene.py
@@ -1,0 +1,92 @@
+import pathlib, sys
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+import torch
+import torch.nn as nn
+from transformers import LlamaConfig
+from training.buffer import ReplayBuffer
+from training.rollout import rollout_collect_k_spec
+from evaluation.acceptance import eval_acceptance
+from kangaroo.earlyexit import EarlyExitLlamaForCausalLM
+
+
+class DummyLayer(nn.Module):
+    def __init__(self, hidden):
+        super().__init__()
+        self.q_proj = nn.Linear(hidden, hidden, bias=False)
+        self.k_proj = nn.Linear(hidden, hidden, bias=False)
+        self.v_proj = nn.Linear(hidden, hidden, bias=False)
+        self.o_proj = nn.Linear(hidden, hidden, bias=False)
+        self.gate_proj = nn.Linear(hidden, hidden, bias=False)
+        self.up_proj = nn.Linear(hidden, hidden, bias=False)
+        self.down_proj = nn.Linear(hidden, hidden, bias=False)
+
+    def forward(self, x, attention_mask=None, position_ids=None, past_key_value=None, output_attentions=False, use_cache=True):
+        if use_cache:
+            B, T, H = x.shape
+            pkv = (
+                torch.zeros(B, 1, T, H, device=x.device, dtype=x.dtype),
+                torch.zeros(B, 1, T, H, device=x.device, dtype=x.dtype),
+            )
+        else:
+            pkv = past_key_value
+        return x, pkv
+
+
+class ToyModel(nn.Module):
+    def __init__(self, cfg):
+        super().__init__()
+        self.embed_tokens = nn.Embedding(cfg.vocab_size, cfg.hidden_size)
+        self.layers = nn.ModuleList([DummyLayer(cfg.hidden_size) for _ in range(cfg.num_hidden_layers)])
+        self.norm = nn.Identity()
+
+    def _prepare_decoder_attention_mask(self, attention_mask, input_shape, inputs_embeds, past_key_values_length):
+        return None
+
+
+class DummyTok:
+    def __call__(self, prompt, return_tensors="pt"):
+        class Batch:
+            def __init__(self):
+                self.input_ids = torch.tensor([[1, 2]], dtype=torch.long)
+
+            def to(self, device):
+                self.input_ids = self.input_ids.to(device)
+                return self
+
+            def get(self, key, default=None):
+                return getattr(self, key, default)
+
+            def __getitem__(self, key):
+                return getattr(self, key)
+
+        return Batch()
+
+
+def make_model():
+    cfg = LlamaConfig(hidden_size=16, intermediate_size=32, num_hidden_layers=4, num_attention_heads=4, vocab_size=128)
+    model = EarlyExitLlamaForCausalLM(cfg, EARLY_STOP_LAYER=2)
+    model.model = ToyModel(cfg)
+    model.lm_head = nn.Linear(cfg.hidden_size, cfg.vocab_size, bias=False)
+    model.exit_proj = nn.Linear(cfg.hidden_size, cfg.vocab_size, bias=False)
+    model.exit_proj.weight = model.lm_head.weight
+    model.head_model = model.lm_head
+    model.past_key_values = None
+    return model
+
+
+def test_rollout_restores_adapter():
+    model = make_model()
+    tok = DummyTok()
+    buf = ReplayBuffer(32, torch.device("cpu"))
+    before = getattr(model, "_dvi_active_adapter", None)
+    rollout_collect_k_spec(model, tok, "hi", buf, steps=2, k=2, greedy=True, temperature=0.0)
+    assert getattr(model, "_dvi_active_adapter", None) == before
+
+
+def test_eval_acceptance_restores_adapter():
+    model = make_model()
+    tok = DummyTok()
+    before = getattr(model, "_dvi_active_adapter", None)
+    eval_acceptance(model, tok, ["hi"], rollout_len=1, steps_per_prompt=1, quiet=True, k_max=1)
+    assert getattr(model, "_dvi_active_adapter", None) == before

--- a/tests/test_ctar_per_prompt.py
+++ b/tests/test_ctar_per_prompt.py
@@ -1,0 +1,10 @@
+import pathlib, sys
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+import pytest
+from training.utils import ctar
+
+
+def test_ctar_per_prompt():
+    seqs = [[1, 1, 0], [1, 1, 1]]
+    assert ctar(seqs, 2) == pytest.approx(0.75)

--- a/train_bestcase.py
+++ b/train_bestcase.py
@@ -438,6 +438,7 @@ def main():
         temperature=max(1e-6, args.temperature),
         early_layer_override=args.early_layer,
         quiet=True,
+        microbatch_base=1
     )
     dvi_time, spec_metrics = dvi_res
     print(f"[time] DVI(SPEC) generate: {dvi_time:.3f}s", flush=True)

--- a/train_bestcase.py
+++ b/train_bestcase.py
@@ -492,6 +492,7 @@ def main():
         repeats=args.time_repeats,
         use_dvi_spec=False,
         temperature=max(1e-6, args.temperature),
+        microbatch_base=1
     )
     print(f"[time] Baseline generate: {base_time:.3f}s", flush=True)
 

--- a/training/modeling.py
+++ b/training/modeling.py
@@ -16,6 +16,7 @@ __all__ = [
     "run_shallow_until_k",
     "run_deep_from_k",
     "exit_logits_from_hidden_k",
+    "cast_exit_to_base_dtype",
 ]
 
 # ---------------------------------------------------------------------------
@@ -192,6 +193,32 @@ def _decoder_layers(model):
     return _llama_model(model).layers
 
 
+def cast_exit_to_base_dtype(model) -> None:
+    """Cast draft head stack to the base model's lm_head dtype for fast inference."""
+    base_dtype = getattr(model.lm_head.weight, "dtype", torch.float16)
+    if hasattr(model, "exit_proj"):
+        model.exit_proj.to(dtype=base_dtype)
+    if hasattr(model, "exit_pre_norm") and model.exit_pre_norm is not None:
+        model.exit_pre_norm.to(dtype=base_dtype)
+    if hasattr(model, "exit_logit_scale"):
+        model.exit_logit_scale.data = model.exit_logit_scale.data.to(base_dtype)
+    try:
+        model._exit_cast_dtype = base_dtype
+    except Exception:
+        pass
+
+
+def _ensure_active_adapter(model, name: str) -> None:
+    """Switch LoRA adapter only when necessary to avoid redundant work."""
+    cur = getattr(model, "_dvi_active_adapter", None)
+    if cur != name:
+        set_active_adapter(model, name)
+        try:
+            model._dvi_active_adapter = name
+        except Exception:
+            pass
+
+
 def run_shallow_until_k(
     model,
     *,
@@ -201,7 +228,7 @@ def run_shallow_until_k(
     use_cache: bool = True,
 ):
     """Run embedding + layers [:k] to obtain hidden at split and updated KVs."""
-    set_active_adapter(model, "draft")
+    _ensure_active_adapter(model, "draft")
     early = _early_model(model)
 
     # Try fast-path only if enabled and KV is actually produced
@@ -233,19 +260,24 @@ def run_shallow_until_k(
     if past_key_values and past_key_values[0] is not None:
         past_len = past_key_values[0][0].shape[2]
 
-    if past_len > 0 and attention_mask is None:
+    if past_len > 0:
         attn_mask = None
+        position_ids = (
+            torch.arange(past_len, past_len + T, device=device)
+            .unsqueeze(0)
+            .expand(B, T)
+        )
         timing_trace("run_shallow_until_k: cached fast-path mask skip")
     else:
         if attention_mask is None:
-            attention_mask = torch.ones((B, past_len + T), dtype=torch.bool, device=device)
+            attention_mask = torch.ones((B, T), dtype=torch.bool, device=device)
         attn_mask = lm._prepare_decoder_attention_mask(
             attention_mask,
             (B, T),
             hidden_states,
-            past_len,
+            0,
         )
-    position_ids = torch.arange(past_len, past_len + T, device=device).unsqueeze(0).expand(B, T)
+        position_ids = torch.arange(0, T, device=device).unsqueeze(0).expand(B, T)
 
     if past_key_values is None:
         past_key_values = tuple([None] * k)
@@ -276,7 +308,7 @@ def run_deep_from_k(
     use_cache: bool = True,
 ):
     """Run only layers [k:] given hidden states at split layer."""
-    set_active_adapter(model, "verify")
+    _ensure_active_adapter(model, "verify")
     early = _early_model(model)
 
     # Try fast-path only if enabled and KV is actually produced
@@ -308,16 +340,21 @@ def run_deep_from_k(
 
     if past_len > 0 and past_key_values is not None:
         attn_mask = None
+        position_ids = (
+            torch.arange(past_len, past_len + T, device=device)
+            .unsqueeze(0)
+            .expand(B, T)
+        )
         timing_trace("run_deep_from_k: cached fast-path mask skip")
     else:
-        attention_mask = torch.ones((B, past_len + T), dtype=torch.bool, device=device)
+        attention_mask = torch.ones((B, T), dtype=torch.bool, device=device)
         attn_mask = lm._prepare_decoder_attention_mask(
             attention_mask,
             (B, T),
             hidden_k,
-            past_len,
+            0,
         )
-    position_ids = torch.arange(past_len, past_len + T, device=device).unsqueeze(0).expand(B, T)
+        position_ids = torch.arange(0, T, device=device).unsqueeze(0).expand(B, T)
 
     deep_layers = lm.layers[k:]
     if past_key_values is None:
@@ -345,26 +382,11 @@ def run_deep_from_k(
 
 
 def exit_logits_from_hidden_k(model, hidden_k: torch.Tensor) -> torch.Tensor:
-    """Project hidden states at split layer to draft logits (dtype-safe)."""
+    """Project hidden states at split layer to draft logits."""
     h = hidden_k
-
-    # Run pre-norm in its own dtype (float32 here)
-    if hasattr(model, "exit_pre_norm") and model.exit_pre_norm is not None and hasattr(model.exit_pre_norm, "weight"):
-        pre_dtype = model.exit_pre_norm.weight.dtype
-        if h.dtype != pre_dtype:
-            h = h.to(pre_dtype)
+    if hasattr(model, "exit_pre_norm") and model.exit_pre_norm is not None:
         h = model.exit_pre_norm(h)
-
-    # _SafeLinear will upcast if needed, but we align explicitly
-    proj_dtype = model.exit_proj.weight.dtype
-    if h.dtype != proj_dtype:
-        h = h.to(proj_dtype)
-
     logits = model.exit_proj(h)
-
     if hasattr(model, "exit_logit_scale"):
-        scale = model.exit_logit_scale
-        if scale.dtype != logits.dtype:
-            scale = scale.to(logits.dtype)
-        logits = scale * logits
+        logits = model.exit_logit_scale.to(logits.dtype) * logits
     return logits

--- a/training/objectives.py
+++ b/training/objectives.py
@@ -20,7 +20,7 @@ def _maybe_clamp_exit_head(model, init_fro: float, max_fro: float, max_fro_ratio
         if max_fro_ratio and max_fro_ratio > 0:
             bound_rel = init_fro * max_fro_ratio
             bound = min(bound, bound_rel) if bound is not None else bound_rel
-        if bound is not None and math.isfinite(n) and n > bound:
+        if bound is not None and matzh.isfinite(n) and n > bound:
             W.mul_(bound / n)
 
 
@@ -37,7 +37,7 @@ def one_mixed_step(model, opt, batch,
                    init_fro: float = None, max_fro: float = 0.0, max_fro_ratio: float = 0.0,
                    ce_mask_by_reward: bool = False):
     dev = next(model.parameters()).device
-    hidden = batch["hidden"].to(dev)
+    hidden = batch["hidden"].clone().to(dev) 
     vlogits = batch["vlogits"].to(dev)
     tokens = batch["token"].to(dev).view(-1)
     rewards = batch.get("reward", torch.ones_like(tokens, dtype=torch.float32, device=dev)).to(dev).view(-1)

--- a/training/objectives.py
+++ b/training/objectives.py
@@ -32,9 +32,10 @@ def _logit_stats(s_logits: torch.Tensor, t_logits: torch.Tensor) -> Tuple[float,
 
 def one_mixed_step(model, opt, batch,
                    temperature=1.0, clip=1.0,
-                   ce_weight=0.20,
+                   ce_weight=0.10,
                    lam_pg=0.0, lam_kl=1.0, ent_weight=0.0,
-                   init_fro: float = None, max_fro: float = 0.0, max_fro_ratio: float = 0.0):
+                   init_fro: float = None, max_fro: float = 0.0, max_fro_ratio: float = 0.0,
+                   ce_mask_by_reward: bool = False):
     dev = next(model.parameters()).device
     hidden = batch["hidden"].to(dev)
     vlogits = batch["vlogits"].to(dev)
@@ -46,20 +47,32 @@ def one_mixed_step(model, opt, batch,
         h = model.exit_pre_norm(h)
     slogits = model.exit_proj(h)
     if hasattr(model, "exit_logit_scale"):
-        slogits = model.exit_logit_scale * slogits
+        slogits = model.exit_logit_scale.to(slogits.dtype) * slogits
 
     slogp = F.log_softmax(slogits, dim=-1)
     sp = slogp.exp()
 
     pi_v = sp.gather(1, tokens.view(-1, 1)).squeeze(1)
-    loss_pg = -(rewards * torch.log(pi_v.clamp_min(1e-8))).mean()
+    pos = rewards.gt(0)
+    count_pos = pos.float().sum().clamp_min(1.0)
+    loss_pg = -(rewards * torch.log(pi_v.clamp_min(1e-8))).sum() / count_pos
 
     tlogits = vlogits.float() / float(temperature)
     tlogp = F.log_softmax(tlogits, dim=-1)
     tp = tlogp.exp()
     kl = F.kl_div(input=slogp, target=tp, reduction="batchmean", log_target=False)
 
-    ce = F.nll_loss(slogp, tokens, reduction="mean") if ce_weight > 0.0 else torch.tensor(0.0, device=dev)
+    if ce_weight > 0.0:
+        if ce_mask_by_reward:
+            mask = rewards > 0
+            if mask.any():
+                ce = F.nll_loss(slogp[mask], tokens[mask], reduction="mean")
+            else:
+                ce = torch.tensor(0.0, device=dev)
+        else:
+            ce = F.nll_loss(slogp, tokens, reduction="mean")
+    else:
+        ce = torch.tensor(0.0, device=dev)
     ent = -(sp * slogp).sum(-1).mean()
 
     loss = lam_pg * loss_pg + lam_kl * kl + ce_weight * ce - ent_weight * ent

--- a/training/spec_decode.py
+++ b/training/spec_decode.py
@@ -8,6 +8,7 @@ from .modeling import (
     run_deep_from_k,
     exit_logits_from_hidden_k,
     cast_exit_to_base_dtype,
+    adapter_guard,
 )
 from .sampling import sample_from_logits
 from .utils import theoretical_compression, count_transformer_layers
@@ -19,6 +20,7 @@ from .mem import timing_trace
 class SpecMetrics:
     proposed: int = 0
     accepted: int = 0
+    committed: int = 0
     steps: int = 0
     deep_tokens: int = 0
     comp_ratio_runtime_est: float = 1.0
@@ -29,12 +31,13 @@ class SpecMetrics:
 
     @property
     def deep_to_commit(self) -> float:
-        return self.deep_tokens / max(1, self.accepted)
+        return self.deep_tokens / max(1, self.committed)
 
     def to_dict(self) -> Dict[str, float]:
         return {
             "spec/proposed": float(self.proposed),
             "spec/accepted": float(self.accepted),
+            "spec/committed": float(self.committed),
             "spec/accept_rate": float(self.accept_rate),
             "spec/deep_tokens": float(self.deep_tokens),
             "spec/deep_to_commit": float(self.deep_to_commit),
@@ -91,19 +94,21 @@ def generate_with_dvi_spec(
     generated: List[List[int]] = [[] for _ in range(B)]
 
     # Prime KV caches on the prompt
-    h_k_prompt, shallow_past = run_shallow_until_k(
-        model,
-        input_ids=input_ids,
-        attention_mask=attn_mask,
-        past_key_values=None,
-        use_cache=True,
-    )
-    _, deep_past = run_deep_from_k(
-        model,
-        hidden_k=h_k_prompt,
-        past_key_values=None,
-        use_cache=True,
-    )
+    with adapter_guard(model, "draft"):
+        h_k_prompt, shallow_past = run_shallow_until_k(
+            model,
+            input_ids=input_ids,
+            attention_mask=attn_mask,
+            past_key_values=None,
+            use_cache=True,
+        )
+    with adapter_guard(model, "verify"):
+        _, deep_past = run_deep_from_k(
+            model,
+            hidden_k=h_k_prompt,
+            past_key_values=None,
+            use_cache=True,
+        )
 
     metrics = SpecMetrics()
     total_new = 0
@@ -117,14 +122,15 @@ def generate_with_dvi_spec(
 
         # ---- draft k tokens ----
         for _ in range(draft_k):
-            h_k, tmp_shallow = run_shallow_until_k(
-                model,
-                input_ids=prev.unsqueeze(1),
-                past_key_values=tmp_shallow,
-                attention_mask=None,
-                use_cache=True,
-            )
-            logits = exit_logits_from_hidden_k(model, h_k)
+            with adapter_guard(model, "draft"):
+                h_k, tmp_shallow = run_shallow_until_k(
+                    model,
+                    input_ids=prev.unsqueeze(1),
+                    past_key_values=tmp_shallow,
+                    attention_mask=None,
+                    use_cache=True,
+                )
+                logits = exit_logits_from_hidden_k(model, h_k)
             nxt = sample_from_logits(logits[:, -1, :], greedy=greedy, temperature=temperature)
             draft_tokens.append(nxt)
             draft_hidden.append(h_k[:, -1, :])
@@ -136,12 +142,13 @@ def generate_with_dvi_spec(
         metrics.proposed += int(B * draft_k)
 
         # ---- verify entire block ----
-        deep_logits, deep_past_full = run_deep_from_k(
-            model,
-            hidden_k=hidden_seq,
-            past_key_values=deep_past,
-            use_cache=True,
-        )
+        with adapter_guard(model, "verify"):
+            deep_logits, deep_past_full = run_deep_from_k(
+                model,
+                hidden_k=hidden_seq,
+                past_key_values=deep_past,
+                use_cache=True,
+            )
         metrics.steps += 1
         metrics.deep_tokens += int(B * draft_k)
         deep_calls = 1
@@ -177,6 +184,7 @@ def generate_with_dvi_spec(
             last_tokens = accepted_block[:, -1]
             total_new += accept_len
             metrics.accepted += int(B * accept_len)
+            metrics.committed += int(B * accept_len)
 
         if total_new >= max_new_tokens:
             break
@@ -184,19 +192,21 @@ def generate_with_dvi_spec(
         # ---- optional single-token fix ----
         if accept_len < draft_k:
             mismatch_tok = verify_argmax[:, accept_len]
-            h_fix, shallow_past = run_shallow_until_k(
-                model,
-                input_ids=mismatch_tok.unsqueeze(1),
-                past_key_values=shallow_past,
-                attention_mask=None,
-                use_cache=True,
-            )
-            _, deep_past = run_deep_from_k(
-                model,
-                hidden_k=h_fix,
-                past_key_values=deep_past,
-                use_cache=True,
-            )
+            with adapter_guard(model, "draft"):
+                h_fix, shallow_past = run_shallow_until_k(
+                    model,
+                    input_ids=mismatch_tok.unsqueeze(1),
+                    past_key_values=shallow_past,
+                    attention_mask=None,
+                    use_cache=True,
+                )
+            with adapter_guard(model, "verify"):
+                _, deep_past = run_deep_from_k(
+                    model,
+                    hidden_k=h_fix,
+                    past_key_values=deep_past,
+                    use_cache=True,
+                )
             metrics.steps += 1
             metrics.deep_tokens += int(B)
             deep_calls += 1
@@ -206,7 +216,7 @@ def generate_with_dvi_spec(
                 generated[b].append(tok_list[b])
             last_tokens = mismatch_tok
             total_new += 1
-            metrics.accepted += int(B)
+            metrics.committed += int(B)
 
         # safety: ensure ≤ 2 deep calls per block
         assert deep_calls <= 2, "Deep called more than twice in a block"

--- a/training/utils.py
+++ b/training/utils.py
@@ -84,14 +84,18 @@ def build_prompts_from_alpaca(limit: int) -> List[str]:
     return prompts
 
 
-def ctar(bits: List[int], w: int) -> float:
-    if len(bits) < w:
-        return 0.0
-    tot = len(bits) - w + 1
+def ctar(seqs: List[List[int]], w: int) -> float:
+    """Compute w-CTAR across multiple bit sequences without cross-boundary leakage."""
     ok = 0
-    for i in range(tot):
-        if all(bits[i + j] == 1 for j in range(w)):
-            ok += 1
+    tot = 0
+    for bits in seqs:
+        if len(bits) < w:
+            continue
+        win = len(bits) - w + 1
+        tot += win
+        for i in range(win):
+            if all(bits[i + j] == 1 for j in range(w)):
+                ok += 1
     return ok / max(1, tot)
 
 
@@ -225,11 +229,15 @@ def measure_generate_walltime(
       - (elapsed_seconds, spec_metrics_dict) if use_dvi_spec=True
 
     Notes:
-      * SPEC microbatch is forced to 1 to avoid 'min across batch' accept_len collapse.
+      * SPEC defaults to microbatch=1 to avoid 'min across batch' accept_len collapse but can be overridden.
       * Baseline can use a larger microbatch for throughput.
     """
     device = next(model.parameters()).device
     model.eval()
+    mb = max(1, int(microbatch_spec if use_dvi_spec else microbatch_base))
+    dtype = next(model.parameters()).dtype
+    mode = "spec" if use_dvi_spec else "base"
+    print(f"[time] mode={mode}; device={device}; dtype={dtype}; microbatch={mb}", flush=True)
 
     # Sane generation config
     try:
@@ -352,9 +360,10 @@ def measure_generate_walltime(
         total_elapsed = 0.0
         agg_proposed = 0
         agg_accepted = 0
+        agg_committed = 0
+        agg_deep = 0
 
         s = 0
-        mb = max(1, int(microbatch_spec if use_dvi_spec else microbatch_base))
 
         while s < B:
             e = min(s + mb, B)
@@ -365,6 +374,8 @@ def measure_generate_walltime(
                     total_elapsed += dt
                     agg_proposed += int(spec_dict.get("spec/proposed", 0))
                     agg_accepted += int(spec_dict.get("spec/accepted", 0))
+                    agg_committed += int(spec_dict.get("spec/committed", 0))
+                    agg_deep += int(spec_dict.get("spec/deep_tokens", 0))
                 else:
                     total_elapsed += _baseline_once(enc_chunk, force_greedy=greedy)
             except RuntimeError as err:
@@ -376,6 +387,8 @@ def measure_generate_walltime(
                         total_elapsed += dt
                         agg_proposed += int(spec_dict.get("spec/proposed", 0))
                         agg_accepted += int(spec_dict.get("spec/accepted", 0))
+                        agg_committed += int(spec_dict.get("spec/committed", 0))
+                        agg_deep += int(spec_dict.get("spec/deep_tokens", 0))
                     else:
                         total_elapsed += _baseline_once(enc_fallback, force_greedy=True)
                     e = s + 1
@@ -391,7 +404,10 @@ def measure_generate_walltime(
             spec_last = {
                 "spec/proposed": float(agg_proposed),
                 "spec/accepted": float(agg_accepted),
+                "spec/committed": float(agg_committed),
                 "spec/accept_rate": float(acc),
+                "spec/deep_tokens": float(agg_deep),
+                "spec/deep_to_commit": float(agg_deep / max(1, agg_committed)),
             }
 
         times.append(total_elapsed)


### PR DESCRIPTION
## Summary
- Normalize policy-gradient loss and optionally mask CE by reward to reduce gradient dilution
- Add adapter_guard context manager and apply draft/verify guards across rollout, eval, and speculative decoding
- Compute CTAR per prompt, align wall-time harness microbatching, and unify eval through generate_with_dvi_spec

## Testing
- `pytest -q`
- `python - <<'PY'
from transformers import AutoModelForCausalLM
try:
    AutoModelForCausalLM.from_pretrained('hf-internal-testing/tiny-random-llama', device_map='cpu')
except Exception as e:
    print(e)
PY` *(fails: Repository Not Found)*


------
https://chatgpt.com/codex/tasks/task_e_68b0a8683adc83248210ae4975cef0da