### PR TITLE
Fix inference-mode tensors breaking training

### DIFF
--- a/evaluation/acceptance.py
+++ b/evaluation/acceptance.py
@@ -25,7 +25,11 @@ def _top1(logits: torch.Tensor) -> int:
     return int(torch.argmax(logits, dim=-1, keepdim=True)[0, 0].item())
 
 
-@torch.inference_mode()
+# ``torch.inference_mode`` creates tensors that carry an "inference" flag and
+# cannot participate in autograd.  Evaluation only needs gradients disabled, so
+# we use ``torch.no_grad`` here to avoid producing inference tensors that could
+# leak into later training phases.
+@torch.no_grad()
 def eval_acceptance(spec: EarlyExitLlamaForCausalLM, tok, prompts: List[str],
                    rollout_len: int, steps_per_prompt: int = 1,
                    dump_debug: bool = False, dump_path: Optional[str] = None, topk: int = 5,

--- a/evaluation/eval.py
+++ b/evaluation/eval.py
@@ -68,7 +68,9 @@ def run_eval(
         ray.get(ans_handles)
 
 
-@torch.inference_mode()
+# Disable gradients without enabling inference mode so any tensors produced
+# here remain compatible with autograd in subsequent training.
+@torch.no_grad()
 def get_model_answers(
         model,
         tokenizer,

--- a/training/objectives.py
+++ b/training/objectives.py
@@ -20,7 +20,7 @@ def _maybe_clamp_exit_head(model, init_fro: float, max_fro: float, max_fro_ratio
         if max_fro_ratio and max_fro_ratio > 0:
             bound_rel = init_fro * max_fro_ratio
             bound = min(bound, bound_rel) if bound is not None else bound_rel
-        if bound is not None and matzh.isfinite(n) and n > bound:
+        if bound is not None and math.isfinite(n) and n > bound:
             W.mul_(bound / n)
 
 

--- a/training/spec_decode.py
+++ b/training/spec_decode.py
@@ -44,7 +44,10 @@ class SpecMetrics:
             "spec/comp_rt_est": float(self.comp_ratio_runtime_est),
         }
 
-@torch.inference_mode()
+# Generation only requires gradients disabled; using ``torch.no_grad`` avoids
+# producing inference tensors that could accidentally leak into later
+# optimisation steps.
+@torch.no_grad()
 def generate_with_dvi_spec(
     model,
     tok,

--- a/training/utils.py
+++ b/training/utils.py
@@ -306,7 +306,9 @@ def measure_generate_walltime(
     def _slice_enc(enc, s, e):
         return {k: v[s:e] for k, v in enc.items()}
 
-    @torch.inference_mode()
+    # ``torch.no_grad`` is sufficient for generation benchmarking here and
+    # avoids returning tensors marked as inference.
+    @torch.no_grad()
     def _baseline_once(enc_chunk, force_greedy: bool) -> float:
         _cuda_sync()
         t0 = time.perf_counter()
@@ -325,7 +327,7 @@ def measure_generate_walltime(
         _cuda_sync()
         return time.perf_counter() - t0
 
-    @torch.inference_mode()
+    @torch.no_grad()
     def _spec_once(enc_chunk) -> (float, Dict[str, float]):
         deep_kv_purge(model)
         from training.spec_decode import generate_with_dvi_spec


### PR DESCRIPTION
## Summary
- clone replay-buffer tensors under `inference_mode(False)` in `one_mixed_step` so autograd can save them for backward
- drop `torch.inference_mode` in evaluation and KV-cache helpers in favor of `torch.no_grad`
- remove remaining `inference_mode` usage in utility and generation code

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b206dcfda88324bd79c8d8d40add5d