### PR TITLE
Avoid NaNs by keeping exit head in fp32 and rebuilding optimizer

### DIFF
--- a/evaluation/acceptance.py
+++ b/evaluation/acceptance.py
@@ -13,7 +13,7 @@ from training.kv import (
     clear_all_kv,
 )
 from training.utils import ctar, free_cuda
-from training.modeling import exit_logits_from_hidden_k, cast_exit_to_base_dtype, adapter_guard
+from training.modeling import exit_logits_from_hidden_k, adapter_guard
 
 __all__ = ["eval_acceptance"]
 
@@ -36,7 +36,6 @@ def eval_acceptance(spec: EarlyExitLlamaForCausalLM, tok, prompts: List[str],
                    quiet: bool = False, k_max: int = 4) -> Tuple[float, Dict[int, float]]:
     global _KV_WARN_COUNT
     spec.eval()
-    cast_exit_to_base_dtype(spec)
     dev = next(spec.parameters()).device
     accepts_seq: List[List[int]] = []
     dbg_out: List[Dict] = []

--- a/train_bestcase.py
+++ b/train_bestcase.py
@@ -65,7 +65,6 @@ def train_bestcase_kl_rl(model, tok, prompts_train: List[str], prompts_eval: Lis
     metrics_path = os.path.join(outdir, "logs", "train_metrics.jsonl")
     samples_path = os.path.join(outdir, "logs", "rollout_samples.jsonl")
 
-    opt = build_optimizer(model, lr_exit=lr_exit, lr_lora=lr_lora, wd_exit=1e-2, wd_lora=0.0)
     buf = ReplayBuffer(capacity=max(4096, batch_size * rollout_len * 8), device=torch.device("cpu"))
 
     model.eval()
@@ -95,6 +94,9 @@ def train_bestcase_kl_rl(model, tok, prompts_train: List[str], prompts_eval: Lis
     for w in range(1, eval_k_max + 1):
         log_dict[f"eval/pre/ctar{w}"] = ctar0.get(w, 0)
     wandb_log(log_dict, step=0)
+
+    # Build optimizer after any dtype casting that may occur during evaluation.
+    opt = build_optimizer(model, lr_exit=lr_exit, lr_lora=lr_lora, wd_exit=1e-2, wd_lora=0.0)
 
     ptr = 0
     tokens_total = 0

--- a/training/rollout.py
+++ b/training/rollout.py
@@ -10,7 +10,6 @@ from training.modeling import (
     run_shallow_until_k,
     run_deep_from_k,
     exit_logits_from_hidden_k,
-    cast_exit_to_base_dtype,
     adapter_guard,
 )
 from training.sampling import sample_from_logits
@@ -58,7 +57,6 @@ def rollout_collect_k_spec(
     """
 
     spec.eval()
-    cast_exit_to_base_dtype(spec)
     device = next(spec.parameters()).device
     enc = tok(prompt, return_tensors="pt")
     input_ids = enc["input_ids"].to(device)

--- a/training/spec_decode.py
+++ b/training/spec_decode.py
@@ -7,7 +7,6 @@ from .modeling import (
     run_shallow_until_k,
     run_deep_from_k,
     exit_logits_from_hidden_k,
-    cast_exit_to_base_dtype,
     adapter_guard,
 )
 from .sampling import sample_from_logits
@@ -65,7 +64,6 @@ def generate_with_dvi_spec(
     """Self-speculative decoding using vectorised block verification."""
 
     model.eval()
-    cast_exit_to_base_dtype(model)
     device = device or next(model.parameters()).device
     k = early_layer if early_layer is not None else getattr(model, "early_layer", None)
     assert isinstance(k, int) and k > 0


### PR DESCRIPTION
## Summary
- Keep exit stack in fp32 by removing `cast_exit_to_base_dtype` from evaluation and rollout paths
- Build the optimizer only after evaluation to align with final parameter dtypes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b21240dd9083249f064e194908ed00