### PR TITLE
Expose DVI Alignment Telemetry via CLI and runtime timing

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,0 +1,52 @@
+# DVI Alignment Telemetry
+
+`AlignTelemetryParams` provides lightweight diagnostics for the drafter–verifier
+alignment in both training and runtime experiments. Telemetry is **off by
+default** and is controlled entirely through CLI flags in `train_bestcase.py`.
+
+When enabled it can:
+
+* emit up to `--telemetry-prints-budget` concise lines to stdout
+  (one per block),
+* write at most `--telemetry-max-blocks` JSON files and optional `.pt`
+  tensor blobs to `--telemetry-save-dir`, and
+* optionally search both offsets `{0,+1}` when computing accepted prefix
+  length with `--telemetry-auto-offset 1`.
+
+## Example usage
+
+### Baseline diagnosis (auto-offset off)
+
+```bash
+CUDA_VISIBLE_DEVICES=0 python train_bestcase.py \
+  --model-id meta-llama/Llama-2-7b-hf \
+  --early-layer 4 \
+  --steps 60 --rollout 2 --batch-size 64 \
+  --lr-exit 5e-4 --lr-lora 5e-5 \
+  --train-k-spec 2 --spec-train-greedy \
+  --outdir runs/k2_telemetry \
+  --eval-every 30 \
+  --spec-k-max 2 \
+  --time-prompts 16 --time-max-new-tokens 64 --time-repeats 1 \
+  --timing-greedy --quiet-eval \
+  --telemetry-debug 1 \
+  --telemetry-prints-budget 6 \
+  --telemetry-dump-tensors 0 \
+  --telemetry-max-blocks 12 \
+  --telemetry-save-dir runs/k2_telemetry/align_dumps \
+  --telemetry-auto-offset 0
+```
+
+### Mitigation trial (auto-offset on)
+
+```bash
+--telemetry-auto-offset 1
+```
+
+## Inspecting dumps
+
+Telemetry files are stored in the directory passed via `--telemetry-save-dir`
+and are named `{run_id}_{phase}_step####.json`.  Each JSON file contains a
+`diag` block with fields such as `match_0`, `match_p1`, `best_offset` and
+`accept_len_default`, together with KV-cache lengths before/after the block.
+A couple of sample JSONs are usually enough to diagnose alignment issues.

--- a/training/rollout.py
+++ b/training/rollout.py
@@ -19,9 +19,16 @@ __all__ = ["rollout_collect", "rollout_collect_k_spec", "buf_debug"]
 
 
 @torch.no_grad()
-def rollout_collect(spec, tok, prompt: str,
-                    buf: ReplayBuffer, steps: int,
-                    debug_out: Optional[List[Dict]] = None, topk: int = 5) -> int:
+def rollout_collect(
+    spec,
+    tok,
+    prompt: str,
+    buf: ReplayBuffer,
+    steps: int,
+    debug_out: Optional[List[Dict]] = None,
+    topk: int = 5,
+    telemetry: Optional[AlignTelemetryParams] = None,
+) -> int:
     """Legacy single-token rollout forwarded to k-spec path."""
     return rollout_collect_k_spec(
         spec,
@@ -34,6 +41,7 @@ def rollout_collect(spec, tok, prompt: str,
         temperature=1.0,
         debug_out=debug_out,
         topk=topk,
+        telemetry=telemetry,
     )
 
 

--- a/training/utils.py
+++ b/training/utils.py
@@ -18,6 +18,7 @@ from transformers import __version__ as transformers_ver
 import time
 from statistics import median
 from .mem import deep_kv_purge, timing_trace
+from .align_telemetry import AlignTelemetryParams
 
 
 __all__ = [
@@ -225,6 +226,7 @@ def measure_generate_walltime(
     microbatch_spec: int = 1,
     # keep the safety cap
     input_cap_tokens: int = 256,
+    telemetry: AlignTelemetryParams | None = None,
 ):
     """
     Returns:
@@ -351,6 +353,7 @@ def measure_generate_walltime(
             early_layer=early_layer_override or getattr(model, "early_layer", None),
             device=device,
             quiet=quiet,
+            telemetry=telemetry,
         )
         _cuda_sync()
         deep_kv_purge(model)


### PR DESCRIPTION
## Summary
- add `--telemetry-*` flags to `train_bestcase.py` and build `AlignTelemetryParams`
- thread telemetry through rollouts, speculative decoding and `measure_generate_walltime`
- document how to enable and inspect telemetry in `docs/telemetry.md`

## Testing
- `python train_bestcase.py --help | head -n 20`
- `python - <<'PY'
from tests.test_train_dvi import make_model
from training.spec_decode import generate_with_dvi_spec
from training.align_telemetry import AlignTelemetryParams
import torch, os
tele = AlignTelemetryParams(debug=1, prints_budget=5, max_blocks=2, save_dir='/tmp/align_demo')
model, cfg = make_model()
enc = {"input_ids": torch.randint(0, cfg.vocab_size, (1,1))}
outs, metrics = generate_with_dvi_spec(model, None, enc=enc, max_new_tokens=2, draft_k=1, telemetry=tele, early_layer=2)
print('files', os.listdir('/tmp/align_demo'))
PY`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9246027248324bdd86d2cc08a829b