### PR TITLE
feat: enable on-policy DVI training with runtime metrics

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -4,6 +4,12 @@
 alignment in both training and runtime experiments. Telemetry is **off by
 default** and is controlled entirely through CLI flags in `train_bestcase.py`.
 
+Policy-gradient training can be enabled with `--use-policy-grad` and is further
+configured via `--rl-weight`, `--pg-baseline-ema`, `--kl-beta0`,
+`--kl-beta-min` and `--kl-anneal-steps`. When enabled, telemetry JSONs also
+record averaged advantages/kl terms and the drafting `eta`/`prefix_hist` per
+block.
+
 When enabled it can:
 
 * emit up to `--telemetry-prints-budget` concise lines to stdout

--- a/evaluation/acceptance.py
+++ b/evaluation/acceptance.py
@@ -15,6 +15,7 @@ from training.kv import (
 from training.utils import ctar, free_cuda
 from training.modeling import exit_logits_from_hidden_k, adapter_guard
 from training.spec_decode import generate_with_dvi_spec
+from training.align_telemetry import AlignTelemetryParams
 
 __all__ = ["eval_acceptance", "eval_runtime_acceptance"]
 
@@ -118,6 +119,8 @@ def eval_runtime_acceptance(
     greedy: bool = True,
     temperature: float = 1.0,
     max_new_tokens: int = 1,
+    quiet: bool = True,
+    telemetry: AlignTelemetryParams | None = None,
 ) -> Dict[str, float]:
     """Run free-form speculative decoding and return runtime metrics."""
 
@@ -131,5 +134,7 @@ def eval_runtime_acceptance(
         greedy=greedy,
         temperature=temperature,
         max_new_tokens=max_new_tokens,
+        quiet=quiet,
+        telemetry=telemetry,
     )
     return metrics.to_dict()

--- a/tests/test_policy_loss.py
+++ b/tests/test_policy_loss.py
@@ -1,28 +1,41 @@
 import torch
+import torch
 import torch.nn as nn
+import contextlib
 import pathlib, sys
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
-from training.objectives import policy_gradient_terms
+import training.objectives as obj_mod
+from training.objectives import policy_gradient_terms, one_policy_step
 
 
 class ToyModel(nn.Module):
     def __init__(self):
         super().__init__()
         self.exit_proj = nn.Linear(2, 2, bias=False)
-
-
-def test_pg_loss_sign_and_kl_scaling():
+def test_pg_loss_sign_and_kl_scaling(monkeypatch):
     model = ToyModel()
+
+    def fake_run_shallow_until_k(model, input_ids, attention_mask=None, past_key_values=None, use_cache=False):
+        hidden = torch.nn.functional.one_hot(input_ids.squeeze(1), num_classes=2).float()
+        return hidden.unsqueeze(1), []
+
+    def fake_exit_logits_from_hidden_k(model, h_k):
+        return model.exit_proj(h_k)
+
+    monkeypatch.setattr(obj_mod, "run_shallow_until_k", fake_run_shallow_until_k)
+    monkeypatch.setattr(obj_mod, "exit_logits_from_hidden_k", fake_exit_logits_from_hidden_k)
+    monkeypatch.setattr(obj_mod, "adapter_guard", lambda *a, **k: contextlib.nullcontext())
+
     batch = {
-        "hidden": torch.zeros(2, 2),
+        "state": torch.tensor([0, 1]),
         "token": torch.tensor([0, 1]),
         "accepted": torch.tensor([1.0, 0.0]),
         "vlogits": torch.zeros(2, 2),
     }
     pg1, kl, _ = policy_gradient_terms(model, batch, baseline_state={"b": 0.0}, baseline_ema=0.0)
     batch_flip = {
-        "hidden": torch.zeros(2, 2),
+        "state": torch.tensor([0, 1]),
         "token": torch.tensor([0, 1]),
         "accepted": torch.tensor([0.0, 1.0]),
         "vlogits": torch.zeros(2, 2),
@@ -35,3 +48,16 @@ def test_pg_loss_sign_and_kl_scaling():
     loss1 = rl_weight * pg1 + beta1 * kl
     loss2 = rl_weight * pg1 + beta2 * kl
     assert torch.allclose(loss2 - rl_weight * pg1, (beta2 / beta1) * (loss1 - rl_weight * pg1), atol=1e-6)
+
+    opt = torch.optim.SGD(model.parameters(), lr=0.1)
+    w0 = model.exit_proj.weight.detach().clone()
+    one_policy_step(
+        model,
+        opt,
+        batch,
+        rl_weight=1.0,
+        beta=0.0,
+        baseline_state={"b": 0.0},
+        baseline_ema=0.0,
+    )
+    assert not torch.allclose(model.exit_proj.weight, w0)

--- a/tests/test_rollout_onpolicy.py
+++ b/tests/test_rollout_onpolicy.py
@@ -66,6 +66,7 @@ def test_rollout_labels_and_tokens(monkeypatch):
     buf = ReplayBuffer(16, torch.device("cpu"))
     rollout_mod.rollout_collect_k_spec(spec, tok, "hi", buf, steps=1, k=2, greedy=True)
     sample = buf.sample_on_policy(2)
+    assert "state" in sample
     mapping = {int(tok): float(acc) for tok, acc in zip(sample["token"], sample["accepted"])}
     assert mapping[0] == 1.0 and mapping[1] == 0.0
 

--- a/train_bestcase.py
+++ b/train_bestcase.py
@@ -18,7 +18,7 @@ import json
 import math
 import time
 import gc
-from typing import List
+from typing import List, Dict
 
 import torch
 
@@ -37,7 +37,7 @@ from training.mem import deep_kv_purge, timing_trace
 from training.modeling import prepare_dvi_trainable, build_optimizer
 from training.kv import estimate_kv_cache
 from training.rollout import rollout_collect, rollout_collect_k_spec, buf_debug
-from training.objectives import one_mixed_step
+from training.objectives import one_mixed_step, one_policy_step
 from training.schedule import mix_schedule, phase_of_step
 from training.logging import (
     init_wandb,
@@ -49,8 +49,7 @@ from training.logging import (
     WANDB_DEFAULT_PROJECT,
 )
 from training.buffer import ReplayBuffer
-from evaluation.acceptance import eval_acceptance
-from training.spec_decode import generate_with_dvi_spec
+from evaluation.acceptance import eval_acceptance, eval_runtime_acceptance
 from training.align_telemetry import AlignTelemetryParams
 import random
 
@@ -76,6 +75,12 @@ def train_bestcase_kl_rl(model, tok, prompts_train: List[str], prompts_eval: Lis
                         eval_k_max: int = None,
                         timing_greedy: bool = False,
                         telemetry: AlignTelemetryParams | None = None,
+                        use_policy_grad: bool = False,
+                        rl_weight: float = 1.0,
+                        pg_baseline_ema: float = 0.9,
+                        kl_beta0: float = 0.5,
+                        kl_beta_min: float = 0.05,
+                        kl_anneal_steps: int = 2000,
                         ):
     metrics_path = os.path.join(outdir, "logs", "train_metrics.jsonl")
     samples_path = os.path.join(outdir, "logs", "rollout_samples.jsonl")
@@ -110,8 +115,32 @@ def train_bestcase_kl_rl(model, tok, prompts_train: List[str], prompts_eval: Lis
         log_dict[f"eval/pre/ctar{w}"] = ctar0.get(w, 0)
     wandb_log(log_dict, step=0)
 
+    rt_prompts_pre = random.sample(prompts_eval, k=min(16, len(prompts_eval)))
+    rt_metrics_pre = eval_runtime_acceptance(
+        model,
+        tok,
+        prompts=rt_prompts_pre,
+        draft_k=train_k_spec,
+        eta=eta,
+        spec_adaptive=spec_adaptive,
+        greedy=timing_greedy,
+        temperature=temperature if not timing_greedy else max(1e-6, temperature),
+        max_new_tokens=32,
+        telemetry=telemetry,
+    )
+    log_rt_pre = {f"eval/runtime/pre/{k}": v for k, v in rt_metrics_pre.items()}
+    wandb_log(log_rt_pre, step=0)
+    hist_msg = " ".join(
+        [f"{k.split('_')[-1]}={int(v)}" for k, v in rt_metrics_pre.items() if k.startswith("spec/prefix_hist_")]
+    )
+    print(
+        f"[eval/runtime] PRE  acc_rate={rt_metrics_pre.get('spec/accept_rate',0.0):.3f} {hist_msg}",
+        flush=True,
+    )
+
     # Build optimizer after any dtype casting that may occur during evaluation.
     opt = build_optimizer(model, lr_exit=lr_exit, lr_lora=lr_lora, wd_exit=1e-2, wd_lora=0.0)
+    pg_baseline_state: Dict[str, float] = {}
 
     ptr = 0
     tokens_total = 0
@@ -213,6 +242,27 @@ def train_bestcase_kl_rl(model, tok, prompts_train: List[str], prompts_eval: Lis
         _cuda_sync()
         t_trn_e = time.perf_counter()
         step_time = (t_trn_e - t_trn_s)
+        policy_stats = None
+        if use_policy_grad:
+            try:
+                pg_batch = buf.sample_on_policy(batch_size)
+            except ValueError:
+                pg_batch = None
+            if pg_batch is not None:
+                frac = min(1.0, g / max(1, kl_anneal_steps))
+                beta = kl_beta0 - (kl_beta0 - kl_beta_min) * frac
+                pol_out = one_policy_step(
+                    model,
+                    opt,
+                    pg_batch,
+                    rl_weight=rl_weight,
+                    beta=beta,
+                    clip=1.0,
+                    baseline_state=pg_baseline_state,
+                    baseline_ema=pg_baseline_ema,
+                )
+                pol_acc = float(pg_batch["accepted"].float().mean().item())
+                policy_stats = {**pol_out, "accepted": pol_acc, "beta": beta}
 
         accept_roll = float(batch["reward"].float().mean().item())
         # per-step compression & speedup estimate (frequent logging)
@@ -233,6 +283,13 @@ def train_bestcase_kl_rl(model, tok, prompts_train: List[str], prompts_eval: Lis
             continue
 
         std_s, std_t = out["std_s_t"]
+        pol_msg = ""
+        if policy_stats:
+            pol_msg = (
+                f" | pol_loss {policy_stats['loss']:+7.4f} pg {policy_stats['pg']:+7.4f}"
+                f" kl {policy_stats['kl']:+7.4f} acc {policy_stats['accepted']:.3f}"
+                f" beta {policy_stats['beta']:.3f}"
+            )
         print(
             f"[train] step {g:04d} | {phase:>10} | "
             f"loss {out['loss']:+7.4f} "
@@ -243,7 +300,7 @@ def train_bestcase_kl_rl(model, tok, prompts_train: List[str], prompts_eval: Lis
             f"||exit||={exit_norm:.2f} | roll_acc≈{accept_roll:.4f} | "
             f"buf_size={buf_size} acc_rate≈{buf_rate:.3f} | λ_pg={lam_pg:.3f} λ_kl={lam_kl:.3f} | accepted_only={accepted_only} | "
             f"KV={kv_mb:.2f} MB (seq≈{kv_seq}) | CUDA alloc={mem_alloc:.1f} MB | "
-            f"comp≈{comp_ratio:.3f} (speedup≈{speedup_est:.2f}×)",
+            f"comp≈{comp_ratio:.3f} (speedup≈{speedup_est:.2f}×)" + pol_msg,
             flush=True,
         )
 
@@ -265,6 +322,15 @@ def train_bestcase_kl_rl(model, tok, prompts_train: List[str], prompts_eval: Lis
             total_layers=total_layers,
             early_layer=early_layer,
         )
+        if policy_stats:
+            metrics.update({
+                "policy/loss": policy_stats["loss"],
+                "policy/pg": policy_stats["pg"],
+                "policy/kl": policy_stats["kl"],
+                "policy/baseline": policy_stats["baseline"],
+                "policy/accepted": policy_stats["accepted"],
+                "policy/beta": policy_stats["beta"],
+            })
         with open(metrics_path, "a") as f:
             f.write(json.dumps(metrics) + "\n")
 
@@ -288,6 +354,15 @@ def train_bestcase_kl_rl(model, tok, prompts_train: List[str], prompts_eval: Lis
             # added: frequent compression logging
             "comp/theoretical_from_train": comp_ratio,
         }, step=g)
+        if policy_stats:
+            wandb_log({
+                "policy/loss": policy_stats["loss"],
+                "policy/pg": policy_stats["pg"],
+                "policy/kl": policy_stats["kl"],
+                "policy/baseline": policy_stats["baseline"],
+                "policy/accepted": policy_stats["accepted"],
+                "policy/beta": policy_stats["beta"],
+            }, step=g)
 
         if dbg_roll:
             with open(samples_path, "a") as f:
@@ -311,24 +386,22 @@ def train_bestcase_kl_rl(model, tok, prompts_train: List[str], prompts_eval: Lis
 
             # ----- runtime-style evaluation (free-running) -----
             rt_prompts = random.sample(prompts_eval, k=min(16, len(prompts_eval)))
-            _, rt_metrics = generate_with_dvi_spec(
+            rt_dict = eval_runtime_acceptance(
                 model,
                 tok,
                 prompts=rt_prompts,
-                max_new_tokens=32,
                 draft_k=train_k_spec,
+                eta=eta,
+                spec_adaptive=spec_adaptive,
                 greedy=timing_greedy,
                 temperature=temperature if not timing_greedy else max(1e-6, temperature),
-                early_layer=early_layer,
-                quiet=True,
+                max_new_tokens=32,
                 telemetry=telemetry,
             )
-            rt_dict = rt_metrics.to_dict()
             rt_dict.update({
                 "spec/greedy": float(timing_greedy),
                 "spec/temperature": float(max(1e-6, temperature) if timing_greedy else temperature),
                 "spec/k": float(train_k_spec),
-                "spec/early_layer": float(early_layer),
             })
             log_rt = {f"eval/runtime/{k}": v for k, v in rt_dict.items()}
             # cross-check CTAR hats vs teacher-forced CTARs
@@ -370,7 +443,31 @@ def train_bestcase_kl_rl(model, tok, prompts_train: List[str], prompts_eval: Lis
     for w in range(1, eval_k_max + 1):
         log_post[f"eval/post/ctar{w}"] = ctar1.get(w, 0)
     wandb_log(log_post, step=steps)
-    wandb_summary_update(log_post)
+
+    rt_prompts_post = random.sample(prompts_eval, k=min(16, len(prompts_eval)))
+    rt_metrics_post = eval_runtime_acceptance(
+        model,
+        tok,
+        prompts=rt_prompts_post,
+        draft_k=train_k_spec,
+        eta=eta,
+        spec_adaptive=spec_adaptive,
+        greedy=timing_greedy,
+        temperature=temperature if not timing_greedy else max(1e-6, temperature),
+        max_new_tokens=32,
+        telemetry=telemetry,
+    )
+    log_rt_post = {f"eval/runtime/post/{k}": v for k, v in rt_metrics_post.items()}
+    wandb_log(log_rt_post, step=steps)
+    hist_msg = " ".join(
+        [f"{k.split('_')[-1]}={int(v)}" for k, v in rt_metrics_post.items() if k.startswith("spec/prefix_hist_")]
+    )
+    print(
+        f"[eval/runtime] POST acc_rate={rt_metrics_post.get('spec/accept_rate',0.0):.3f} {hist_msg}",
+        flush=True,
+    )
+
+    wandb_summary_update({**log_post, **log_rt_post})
 
     deep_kv_purge(model)
     gc.collect()
@@ -397,6 +494,12 @@ def main():
     ap.add_argument("--ce-weight", type=float, default=0.10)
     ap.add_argument("--ce-mask-by-reward", action="store_true")
     ap.add_argument("--ent-weight", type=float, default=0.00)
+    ap.add_argument("--use-policy-grad", action="store_true")
+    ap.add_argument("--rl-weight", type=float, default=1.0)
+    ap.add_argument("--pg-baseline-ema", type=float, default=0.9)
+    ap.add_argument("--kl-beta0", type=float, default=0.5)
+    ap.add_argument("--kl-beta-min", type=float, default=0.05)
+    ap.add_argument("--kl-anneal-steps", type=int, default=2000)
     ap.add_argument("--warmup-kl", type=int, default=40)
     ap.add_argument("--ramp-steps", type=int, default=80)
     ap.add_argument("--kl-min", type=float, default=0.05)
@@ -542,6 +645,12 @@ def main():
         eval_k_max=args.eval_k_max,
         timing_greedy=args.timing_greedy,
         telemetry=telemetry,
+        use_policy_grad=args.use_policy_grad,
+        rl_weight=args.rl_weight,
+        pg_baseline_ema=args.pg_baseline_ema,
+        kl_beta0=args.kl_beta0,
+        kl_beta_min=args.kl_beta_min,
+        kl_anneal_steps=args.kl_anneal_steps,
     )
     deep_kv_purge(model)
     gc.collect()

--- a/training/buffer.py
+++ b/training/buffer.py
@@ -19,6 +19,7 @@ class ReplayBuffer:
 
         # Storage buffers
         self._hidden_buf: Optional[torch.Tensor] = None
+        self._state_buf = torch.empty(self.capacity, dtype=torch.long, device=self.device)
         self._token_buf = torch.empty(self.capacity, dtype=torch.long, device=self.device)
         self._reward_buf = torch.empty(self.capacity, dtype=torch.float32, device=self.device)
         self._conf_buf = torch.empty(self.capacity, dtype=torch.float32, device=self.device)
@@ -36,6 +37,7 @@ class ReplayBuffer:
         reward: float,
         conf: float,
         vlogits: Optional[torch.Tensor] = None,
+        state: Optional[int] = None,
     ) -> bool:
         """Append a transition and return ``True`` if an old slot was overwritten."""
         if self._hidden_buf is None:
@@ -49,6 +51,7 @@ class ReplayBuffer:
             logging.debug("Overwriting index %d with token %d", idx, int(token))
 
         self._hidden_buf[idx].copy_(hidden.detach().to(self.device))
+        self._state_buf[idx] = int(state) if state is not None else 0
         self._token_buf[idx] = int(token)
         self._reward_buf[idx] = float(reward)
         self._conf_buf[idx] = float(conf)
@@ -67,7 +70,7 @@ class ReplayBuffer:
     @torch.no_grad()
     def sample(self, batch_size: int, accepted_only: bool = True) -> Dict[str, torch.Tensor]:
         """Sample a batch of transitions uniformly."""
-        if self._size == 0 or self._hidden_buf is None:
+        if self._size == 0:
             raise ValueError("Buffer is empty")
 
         mask = self._reward_buf[: self._size] == 1.0
@@ -109,7 +112,7 @@ class ReplayBuffer:
 
         choice = torch.randperm(self._size, device=self.device)[:batch_size]
         out = {
-            "hidden": self._hidden_buf[choice].clone(),
+            "state": self._state_buf[choice].clone(),
             "token": self._token_buf[choice].clone(),
             "accepted": self._reward_buf[choice].clone(),
         }


### PR DESCRIPTION
## Summary
- add state-aware replay buffer and on-policy rollout collection
- implement REINFORCE + verifier KL policy step with EMA baseline
- integrate runtime acceptance metrics and policy-grad flags in trainer

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9c24f6e548324a50f0f85c22d6001