### PR TITLE
Fix decoder layer count and optional KV purge

### DIFF
--- a/tests/test_decoder_layers.py
+++ b/tests/test_decoder_layers.py
@@ -1,0 +1,47 @@
+import torch
+
+from training.utils import get_num_decoder_layers
+from training import utils as u
+
+
+def test_get_num_decoder_layers_plain():
+    class Plain(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.layers = torch.nn.ModuleList([torch.nn.Linear(1, 1) for _ in range(5)])
+            self.config = type("cfg", (), {"num_hidden_layers": 5})()
+
+    m = Plain()
+    assert get_num_decoder_layers(m) == 5
+
+
+def test_get_num_decoder_layers_peft_like():
+    class Inner(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.layers = torch.nn.ModuleList([torch.nn.Linear(1, 1) for _ in range(4)])
+            self.config = type("cfg", (), {"num_hidden_layers": 4})()
+
+    class Wrapper(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.base_model = type("base", (), {"model": Inner()})()
+            self.config = self.base_model.model.config
+
+    w = Wrapper()
+    assert get_num_decoder_layers(w) == 4
+
+
+def test_get_num_decoder_layers_fallback_warning(capsys):
+    u._num_layers_warned = False
+
+    class Fallback(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.config = type("cfg", (), {"num_hidden_layers": 7})()
+
+    m = Fallback()
+    assert get_num_decoder_layers(m) == 7
+    captured = capsys.readouterr()
+    assert "num_hidden_layers" in captured.out
+

--- a/tests/test_measure_generate_walltime_purge.py
+++ b/tests/test_measure_generate_walltime_purge.py
@@ -1,0 +1,70 @@
+import torch
+
+from training import utils
+
+
+class DummyTok:
+    eos_token_id = 0
+    pad_token_id = 0
+    bos_token_id = 0
+    truncation_side = "right"
+    model_max_length = 8
+
+    def __call__(self, texts, return_tensors="pt", padding=True, truncation=True, max_length=None):
+        ids = torch.zeros((len(texts), 1), dtype=torch.long)
+        attn = torch.ones_like(ids)
+        return {"input_ids": ids, "attention_mask": attn}
+
+
+class DummyModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.lin = torch.nn.Linear(1, 1)
+        self.past_key_values = None
+        self.config = type(
+            "cfg",
+            (),
+            {
+                "eos_token_id": 0,
+                "pad_token_id": 0,
+                "bos_token_id": 0,
+                "use_cache": True,
+            },
+        )()
+
+    def get_input_embeddings(self):
+        return torch.nn.Embedding(1, 1)
+
+    def generate(self, **kwargs):
+        return kwargs["input_ids"]
+
+
+def _run(debug_flag: bool, monkeypatch):
+    calls = {"n": 0}
+
+    def fake_purge(model):
+        calls["n"] += 1
+
+    monkeypatch.setattr(utils, "deep_kv_purge", fake_purge)
+    model = DummyModel()
+    tok = DummyTok()
+    utils.measure_generate_walltime(
+        model,
+        tok,
+        ["hi"],
+        max_new_tokens=1,
+        greedy=True,
+        repeats=1,
+        use_dvi_spec=False,
+        debug_purge_kv=debug_flag,
+    )
+    return calls["n"]
+
+
+def test_no_purge_by_default(monkeypatch):
+    assert _run(False, monkeypatch) == 0
+
+
+def test_debug_purge_enabled(monkeypatch):
+    assert _run(True, monkeypatch) > 0
+


### PR DESCRIPTION
## Summary
- add robust `get_num_decoder_layers` with fallback warning and CLI override
- avoid expensive deep KV purges unless `--debug-purge-kv` is enabled
- expose decoder-layer override and debug purge flags in `train_bestcase.py`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb2a9f6914832483fd44114ece9141